### PR TITLE
Absolute path for configs folder

### DIFF
--- a/src/main/java/de/tudarmstadt/ukp/dariah/pipeline/RunPipeline.java
+++ b/src/main/java/de/tudarmstadt/ukp/dariah/pipeline/RunPipeline.java
@@ -490,7 +490,12 @@ public class RunPipeline {
 
 		LinkedList<String> configFiles = new LinkedList<>();
 
-		String configFolder = "configs/";
+		// Get absolute path of the JAR file
+		RunPipeline referenceClass = new RunPipeline();
+		File jarPath = new File(referenceClass.getClass().getProtectionDomain().getCodeSource().getLocation().getPath());
+		// Construct absolute path to configs dir
+		String configFolder = jarPath.getParentFile().getAbsolutePath()+"/configs/";
+
 		configFiles.add(configFolder+"default.properties");
 		
 		
@@ -695,3 +700,4 @@ public class RunPipeline {
 		}
 	}
 }
+


### PR DESCRIPTION
I guess this PR is related to #23. The `configs` folder is expected in the current directory, which makes such a command impossible:

```
$ java -Xmx4g -jar ddw-0.4.6/ddw-0.4.6.jar -input corpus -output .
```

Using the _absolute_ path to `configs` (which must still be relative to the JAR file) allows you to be anywhere. Or am I missing something?